### PR TITLE
Add relationship helpers

### DIFF
--- a/log.py
+++ b/log.py
@@ -91,7 +91,8 @@ def save_simulation_data(world: World, filename: str = "simulation_snapshot.json
             "age": p.age,
             "mood": p.mood,
             "energy": p.energy,
-            "relationships": p.relationships, # Assuming relationships are simple dicts
+            # Relationships are maintained via Person helper methods
+            "relationships": p.relationships,
             "event_cooldown": p.event_cooldown
         }
         simulation_data["people"].append(person_data)

--- a/person.py
+++ b/person.py
@@ -9,6 +9,19 @@ class Person:
     relationships: dict=field(default_factory=dict)
     event_cooldown:int = 0
 
+    def add_relationship(self, other_name: str, initial: int = 0):
+        """Ensure a relationship entry exists with another person."""
+        if other_name not in self.relationships:
+            self.relationships[other_name] = initial
+
+    def remove_relationship(self, other_name: str):
+        """Remove a relationship entry if present."""
+        self.relationships.pop(other_name, None)
+
+    def get_relationship(self, other_name: str):
+        """Return the relationship value with another person or ``None``."""
+        return self.relationships.get(other_name)
+
     def print_stats(self):
         print(f"\n{self.name}\nMood: {self.mood}\nEnergy: {self.energy}")
 
@@ -29,8 +42,7 @@ class Person:
         print(f"{self.name} just took a nap")
 
     def socialize(self, other: 'Person'):
-        if other.name not in self.relationships:
-            self.relationships[other.name] = 0
+        self.add_relationship(other.name)
         self.relationships[other.name] += 1
         self.mood = min(self.mood + 15, 100)
         other.mood = min(other.mood + 15, 100)


### PR DESCRIPTION
## Summary
- add helper methods to Person for managing relationships
- use helper inside socialize
- note helper use in log save method

## Testing
- `python -m py_compile person.py log.py world.py event.py utils.py main.py`
- `python main.py` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_686c2c61845483239d529ef290194016