### PR TITLE
Add daily stats export

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ def main_loop():
     # After the loop, save data and plot graphs
     save_simulation_data(world, "final_simulation_state.json")
     logger.save_logs_to_file("detailed_simulation_events.json")
+    logger.export_daily_statistics("daily_statistics.json")
 
     plot_all_trends(logger, world) # Call the new combined plotting function
 


### PR DESCRIPTION
## Summary
- export per-person daily averages to JSON
- invoke daily statistics export in the main loop

## Testing
- `python -m py_compile *.py`
- `python main.py` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_686c2c5c42748323898b737c9d55e941